### PR TITLE
add update/delete functionality to counselors and attendees

### DIFF
--- a/app/Attendee.php
+++ b/app/Attendee.php
@@ -4,15 +4,24 @@ namespace App;
 
 use DB;
 use Carbon\Carbon;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class Attendee
  */
 class Attendee extends \Eloquent {
+
+    use SoftDeletes;
+
     /**
      * @var array
      */
-    protected $fillable = ['first_name', 'last_name', 'suffix', 'identifier'];
+    protected $fillable = [
+        'first_name',
+        'last_name',
+        'suffix',
+        'identifier'
+    ];
 
     /**
      * @return A relationship of all the counselors

--- a/app/Counselor.php
+++ b/app/Counselor.php
@@ -2,10 +2,15 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\SoftDeletes;
+
 /**
  * Class Counselor
  */
 class Counselor extends \Eloquent {
+
+    use SoftDeletes;
+
     /**
      * @var array
      */

--- a/app/Http/Controllers/AttendeesController.php
+++ b/app/Http/Controllers/AttendeesController.php
@@ -89,13 +89,25 @@ class AttendeesController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update($id)
     {
-        //
+        $attendee = Attendee::find($id);
+
+        if(!$attendee)
+        {
+            return $this->respondNotFound('Attendee does not exist.');
+        }
+
+        if($attendee->update(Input::all()))
+        {
+            return $this->respond(['message' => 'The attendee has been successfully updated.']);
+        }
+        else {
+            return $this->respondUnprocessableEntity('There was a problem updating the attendee.');
+        }
     }
 
     /**
@@ -145,6 +157,19 @@ class AttendeesController extends ApiController
      */
     public function destroy($id)
     {
-        //
+        $attendee = Attendee::find($id);
+
+        if(!$attendee)
+        {
+            return $this->respondNotFound('Attendee does not exist.');
+        }
+
+        if($attendee->delete())
+        {
+            return $this->respond(['message' => 'The attendee has been deleted.']);
+        }
+        else {
+            return $this->respondUnprocessableEntity('There was a problem deleting the attendee.');
+        }
     }
 }

--- a/app/Http/Controllers/CounselorsController.php
+++ b/app/Http/Controllers/CounselorsController.php
@@ -88,13 +88,25 @@ class CounselorsController extends ApiController
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update($id)
     {
-        //
+        $counselor = Counselor::find($id);
+
+        if(!$counselor)
+        {
+            return $this->respondNotFound('Counselor does not exist.');
+        }
+
+        if($counselor->update(Input::all()))
+        {
+            return $this->respond(['message' => 'The counselor has been successfully updated.']);
+        }
+        else {
+            return $this->respondUnprocessableEntity('There was a problem updating the counselor.');
+        }
     }
 
     /**
@@ -105,6 +117,19 @@ class CounselorsController extends ApiController
      */
     public function destroy($id)
     {
-        //
+        $counselor = Counselor::find($id);
+
+        if(!$counselor)
+        {
+            return $this->respondNotFound('Counselor does not exist.');
+        }
+
+        if($counselor->delete())
+        {
+            return $this->respond(['message' => 'The counselor has been deleted.']);
+        }
+        else {
+            return $this->respondUnprocessableEntity('There was a problem deleting the counselor.');
+        }
     }
 }

--- a/app/Http/Controllers/CounselorsController.php
+++ b/app/Http/Controllers/CounselorsController.php
@@ -34,16 +34,6 @@ class CounselorsController extends ApiController
     }
 
     /**
-     * Show the form for creating a new resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function create()
-    {
-        //
-    }
-
-    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -53,7 +43,7 @@ class CounselorsController extends ApiController
     {
         if(!Input::get('identifier') or !Input::get('first_name') or !Input::get('last_name'))
         {
-            return $this->respondUnprocessableEntity('Parameters failed validation for an counselor.');
+            return $this->respondUnprocessableEntity('Parameters failed validation for a counselor.');
         }
 
         Counselor::create(Input::all());
@@ -86,24 +76,13 @@ class CounselorsController extends ApiController
 
         if(!$counselor)
         {
-            return $this->respondNotFound('Counselor does not exist');
+            return $this->respondNotFound('Counselor does not exist.');
         }
 
         return $this->respond([
             'data' => $this->counselorTransformer->transform($counselor)
         ]);
 
-    }
-
-    /**
-     * Show the form for editing the specified resource.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function edit($id)
-    {
-        //
     }
 
     /**

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e598e4415a27b890ff5906703d383eae",
-    "content-hash": "63a997955126fed5c159d6c75365c2ea",
+    "hash": "1b5c5bbca9e7d5f2e98814a7ea95fd15",
+    "content-hash": "a2ef2377dd76aa82dab80e2ba57ea619",
     "packages": [
         {
             "name": "classpreloader/classpreloader",
@@ -354,16 +354,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v5.2.22",
+            "version": "v5.2.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4"
+                "reference": "87c090845f135ca94eba903f1c8462e60e3a6e36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
-                "reference": "aec1b7cb9ec0bac0107361a3730cac9b6f945ef4",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/87c090845f135ca94eba903f1c8462e60e3a6e36",
+                "reference": "87c090845f135ca94eba903f1c8462e60e3a6e36",
                 "shasum": ""
             },
             "require": {
@@ -478,7 +478,7 @@
                 "framework",
                 "laravel"
             ],
-            "time": "2016-02-27 22:09:19"
+            "time": "2016-03-14 14:22:33"
         },
         {
             "name": "league/flysystem",

--- a/tests/AttendeesTest.php
+++ b/tests/AttendeesTest.php
@@ -193,4 +193,76 @@ class AttendeesTest extends ApiTester
         $this->assertObjectHasAttributes($response->error, 'message');
         $this->assertContains('Attendee does not exist.', $response->error->message);
     }
+
+    /**
+     * @test
+     */
+    public function it_updates_an_attendee_with_a_first_and_last_name()
+    {
+        //arrange
+        $this->make('App\Attendee');
+        $attendee = App\Attendee::first();
+
+        //act
+        $response = $this->getJson('attendees/' . $attendee->id, 'PATCH', ['first_name' => 'Test', 'last_name' => 'Tester']);
+        $attendee = App\Attendee::first();
+
+        //assert
+        $this->assertResponseStatus(200);
+        $this->assertObjectHasAttributes($response, 'message');
+        $this->assertContains('The attendee has been successfully updated.', $response->message);
+        $this->assertEquals($attendee->first_name, 'Test');
+        $this->assertEquals($attendee->last_name, 'Tester');
+
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_a_404_if_an_attendee_is_not_found_when_attempting_to_update_a_attendee()
+    {
+        //act
+        $response = $this->getJson('attendees/x', 'PATCH', ['first_name' => 'John', 'last_name' => 'Doe']);
+
+        //assert
+        $this->assertResponseStatus(404);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Attendee does not exist.', $response->error->message);
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_an_attendee()
+    {
+        //arrange
+        $this->make('App\Attendee');
+        $attendee = App\Attendee::first();
+
+        //act
+        $response = $this->getJson('attendees/' . $attendee->id, 'DELETE');
+        $attendee = App\Attendee::onlyTrashed()->find($attendee->id);
+
+        //assert
+        $this->assertResponseStatus(200);
+        $this->assertObjectHasAttributes($response, 'message');
+        $this->assertContains('The attendee has been deleted.', $response->message);
+        $this->assertEquals($attendee->trashed(), True);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_a_404_if_an_attendee_is_not_found_when_attempting_to_delete_it()
+    {
+        //act
+        $response = $this->getJson('attendees/x', 'DELETE');
+
+        //assert
+        $this->assertResponseStatus(404);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Attendee does not exist.', $response->error->message);
+    }
 }

--- a/tests/CounselorsTest.php
+++ b/tests/CounselorsTest.php
@@ -23,10 +23,12 @@ class CounselorsTest extends ApiTester
         $this->times(5)->make('App\Counselor');
 
         //act
-        $this->getJson('counselors');
+        $response = $this->getJson('counselors');
 
         //assert
         $this->assertResponseOk();
+        $this->assertObjectHasAttributes($response, 'data');
+        $this->assertCount(5, $response->data);
     }
 
     /**
@@ -58,10 +60,13 @@ class CounselorsTest extends ApiTester
     public function it_throws_a_404_if_a_counselor_is_not_found()
     {
         //act
-        $this->getJson('counselors/x');
+        $response = $this->getJson('counselors/x');
 
         //assert
         $this->assertResponseStatus(404);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Counselor does not exist.', $response->error->message);
     }
 
     /**
@@ -82,9 +87,12 @@ class CounselorsTest extends ApiTester
     public function it_throws_a_422_if_a_new_counselor_request_fails_validation()
     {
         //act
-        $this->getJson('counselors', 'POST');
+        $response = $this->getJson('counselors', 'POST');
 
         //assert
         $this->assertResponseStatus(422);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Parameters failed validation for a counselor.', $response->error->message);
     }
 }

--- a/tests/CounselorsTest.php
+++ b/tests/CounselorsTest.php
@@ -95,4 +95,79 @@ class CounselorsTest extends ApiTester
         $this->assertObjectHasAttributes($response->error, 'message');
         $this->assertContains('Parameters failed validation for a counselor.', $response->error->message);
     }
+
+    /**
+     * @test
+     */
+    public function it_updates_a_counselor_with_a_first_and_last_name()
+    {
+        //arrange
+        $this->make('App\Counselor');
+        $counselor = App\Counselor::first();
+        $old_first_name = $counselor->first_name;
+        $old_last_name = $counselor->last_name;
+
+        //act
+        $response = $this->getJson('counselors/' . $counselor->id, 'PATCH', ['first_name' => 'Test', 'last_name' => 'Tester']);
+        $counselor = App\Counselor::first();
+
+        //assert
+        $this->assertResponseStatus(200);
+        $this->assertObjectHasAttributes($response, 'message');
+        $this->assertContains('The counselor has been successfully updated.', $response->message);
+        $this->assertEquals($counselor->first_name, 'Test');
+        $this->assertEquals($counselor->last_name, 'Tester');
+
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_a_404_if_a_counselor_is_not_found_when_attempting_to_update_a_counselor()
+    {
+        //act
+        $response = $this->getJson('counselors/x', 'PATCH', ['first_name' => 'John', 'last_name' => 'Doe']);
+
+        //assert
+        $this->assertResponseStatus(404);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Counselor does not exist.', $response->error->message);
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_a_counselor()
+    {
+        //arrange
+        $this->make('App\Counselor');
+        $counselor = App\Counselor::first();
+
+        //act
+        $response = $this->getJson('counselors/' . $counselor->id, 'DELETE');
+        $counselor = App\Counselor::onlyTrashed()->find($counselor->id);
+
+        //assert
+        $this->assertResponseStatus(200);
+        $this->assertObjectHasAttributes($response, 'message');
+        $this->assertContains('The counselor has been deleted.', $response->message);
+        $this->assertEquals($counselor->trashed(), True);
+
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_a_404_if_a_counselor_is_not_found_when_attempting_to_delete_it()
+    {
+        //act
+        $response = $this->getJson('counselors/x', 'DELETE');
+
+        //assert
+        $this->assertResponseStatus(404);
+        $this->assertObjectHasAttributes($response, 'error');
+        $this->assertObjectHasAttributes($response->error, 'message');
+        $this->assertContains('Counselor does not exist.', $response->error->message);
+    }
 }


### PR DESCRIPTION
Cleanup/improve counselor tests.
Remove a few unnecessary controller methods.
Fix some counselor verbiage and tests.
Add more assertions to Counselor tests.
Add SoftDelete trait to both attendee and counselor.
Add update/delete methods to counselors and attendees.
Add tests around update and delete functionality for attendees and counselors.
Update to Laravel 5.2.23